### PR TITLE
replaces the gulp css minify task with cssnano

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,7 @@ var sass            = require('gulp-sass');
 var sourcemaps      = require('gulp-sourcemaps');
 var autoprefixer    = require('gulp-autoprefixer');
 var notify          = require("gulp-notify");
-var minifyCss       = require('gulp-minify-css');
+var cssnano       = require('gulp-cssnano');
 
 // Image Stuff
 
@@ -96,7 +96,7 @@ gulp.task('sass:build', function () {
     .src(SassInput)
     .pipe(sass())
     .pipe(autoprefixer(autoprefixerOptions))
-    .pipe(minifyCss())
+    .pipe(cssnano())
     .pipe(gulp.dest(SassOutputBuild));
 });
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^2.3.1",
     "gulp-connect-php": "0.0.5",
+    "gulp-cssnano": "^2.1.1",
     "gulp-filter": "^2.0.2",
     "gulp-imagemin": "^2.3.0",
     "gulp-minify-css": "^1.1.6",


### PR DESCRIPTION
**What's this PR do?**
This replaces the gulp plugin being used to minify CSS with cssnano -- the existing plugin minify-css is now defunct.

**Any background context you want to provide?**
I'm tidying up the gulpfile for the UI Library so it's concentrated on it's deployment 'ready-ness'.

