### PR TITLE
adds filesize stats

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,6 +37,7 @@ var bump            = require('gulp-bump');
 var filter          = require('gulp-filter');
 var tag_version     = require('gulp-tag-version');
 var stylestats      = require('gulp-stylestats');
+var checkFilesize   = require("gulp-check-filesize");
 
 // -----------------------------------------------------------------------------
 // Configuration
@@ -237,7 +238,8 @@ gulp.task('release', function() { return inc('major'); })
 
 gulp.task('stats', function () {
   gulp.src('./tmp/**/*.css')
-    .pipe(stylestats());
+    .pipe(stylestats())
+    .pipe(checkFilesize({enableGzip: true}));
 });
 
 // -----------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "del": "^1.2.0",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^2.3.1",
+    "gulp-check-filesize": "^2.0.1",
     "gulp-connect-php": "0.0.5",
     "gulp-cssnano": "^2.1.1",
     "gulp-filter": "^2.0.2",


### PR DESCRIPTION
Added this gulp plugin so we can get a look at the file size of the CSS (and what it could be when gzipped) to go with the stats plugin.