### PR TITLE
replaces url path for Windows environment development closes #22

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -101,7 +101,7 @@ gulp.task('sass:deploy', function () {
     .src(SassInput)
     .pipe(sass())
     .pipe(autoprefixer(autoprefixerOptions))
-    .pipe(replace('../images/', 'http://www.monotype.com/Content/Vendor/image/'))
+    .pipe(replace('../images/', '../../'))
     .pipe(cssnano())
     .pipe(gulp.dest(SassOutputBuild));
 });


### PR DESCRIPTION
This adds a new task for creating a build for the main site.
Use gulp deploy to build a project using ../../image instead of ../images for developing on Windows.

This closes #22