### PR TITLE
CSS for German Website, its footer text are truncated

### DIFF
--- a/scss/block/_footer-list.scss
+++ b/scss/block/_footer-list.scss
@@ -66,6 +66,15 @@
     font-family: $kootenay-bold;
   }
 }
+:lang(de) { // Specific for language DE only
+  .b-footer-list__list {
+    .b-footer-list__item.g-col-2-3 {
+      @include breakpoint(fromAdaptiveToFluid) {
+        margin-left: 3%;
+      }
+    }
+  }
+}
 .b-footer-list__secondlevel {
 
   .b-footer-list__secondlevel-item:last-child {


### PR DESCRIPTION
## Proposed changes

1) Navigate to URL: http://beta.monotype.com/de/expertise/
2) Scroll Down to the bottom of the page.
3) Observe the footer.

Actual Result:
"Anwendungsbeispiele" word will appear as truncated.

Expected Result:
There should be no truncation.

## Does this close any currently open issues?

https://github.com/monotype-digital-design/UILibrary/issues/39

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Code compiles correctly
- [ ] Extended the README / documentation, if necessary

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

### Reviewers: @sturobson @realdeepak

CSS fixed for footer truncation.